### PR TITLE
refact(tooling): extract and clean distribution process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
   - docker
 
 go:
-  - 1.8
   - tip
 
 env:

--- a/Makefile
+++ b/Makefile
@@ -1,149 +1,35 @@
-dist: macos linux docker
-	rm -rf dist/macos dist/linux dist/docker
-	cp INSTALLATION.md dist/
+.DEFAULT_GOAL := dist
 
-macos:
-	@rm -rf dist/macos
-	@mkdir -p dist/macos/apps
-	@echo '************************************'
-	@echo MACOS: prepare vscode app
-	@echo '************************************'
-	wget -q --output-document=$(shell pwd)/dist/macos/apps/vscode.zip https://go.microsoft.com/fwlink/?LinkID=620882
-	wget -q --output-document=$(shell pwd)/dist/macos/apps/go.vsix https://lukehoban.gallery.vsassets.io/_apis/public/gallery/publisher/lukehoban/extension/Go/0.6.57/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage
-	unzip -q $(shell pwd)/dist/macos/apps/vscode.zip -d $(shell pwd)/dist/macos/apps/
-	@rm $(shell pwd)/dist/macos/apps/vscode.zip
-	@echo '************************************'
-	@echo MACOS: prepare golang app
-	@echo '************************************'
-	wget -q --output-document=$(shell pwd)/dist/macos/apps/go.tar.gz https://storage.googleapis.com/golang/go1.8.darwin-amd64.tar.gz
-	tar -C $(shell pwd)/dist/macos/apps/ -xzf $(shell pwd)/dist/macos/apps/go.tar.gz
-	@rm $(shell pwd)/dist/macos/apps/go.tar.gz
-	@echo '************************************'
-	@echo MACOS: prepare jq
-	@echo '************************************'
-	@mkdir -p $(shell pwd)/dist/macos/apps/bin
-	wget -q --output-document=$(shell pwd)/dist/macos/apps/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
-	chmod +x $(shell pwd)/dist/macos/apps/bin/jq
-	@echo '************************************'
-	@echo MACOS: prepare glide
-	@echo '************************************'
-	@mkdir -p $(shell pwd)/dist/macos/tmp_glide
-	wget -q --output-document=$(shell pwd)/dist/macos/tmp_glide/glide.zip https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-darwin-amd64.zip
-	unzip -q $(shell pwd)/dist/macos/tmp_glide/glide.zip -d $(shell pwd)/dist/macos/tmp_glide/
-	@mkdir -p $(shell pwd)/dist/macos/workspace/bin/
-	mv $(shell pwd)/dist/macos/tmp_glide/**/glide $(shell pwd)/dist/macos/workspace/bin/
-	@rm -rf $(shell pwd)/dist/macos/tmp_glide
-	@echo '************************************'
-	@echo MACOS: prepare tools
-	@echo '************************************'
-	cp macos/* dist/macos/
-	cp vscode_settings.json dist/macos/
-	@echo '************************************'
-	@echo MACOS: prepare workspace
-	@echo '************************************'
-	@mkdir -p dist/macos/workspace/src/github.com/Sfeir
-	@mkdir -p dist/macos/workspace/bin
-	@mkdir -p dist/macos/workspace/pkg
-	git clone -q -b start https://github.com/Sfeir/handsongo.git dist/macos/workspace/src/github.com/Sfeir/handsongo
-	export GOPATH=$(shell pwd)/dist/macos/workspace; GOOS=darwin GOARCH=amd64 go get -u github.com/nsf/gocode
-	export GOPATH=$(shell pwd)/dist/macos/workspace; GOOS=darwin GOARCH=amd64 go get -u github.com/rogpeppe/godef
-	export GOPATH=$(shell pwd)/dist/macos/workspace; GOOS=darwin GOARCH=amd64 go get -u github.com/golang/lint/golint
-	export GOPATH=$(shell pwd)/dist/macos/workspace; GOOS=darwin GOARCH=amd64 go get -u github.com/lukehoban/go-outline
-	export GOPATH=$(shell pwd)/dist/macos/workspace; GOOS=darwin GOARCH=amd64 go get -u sourcegraph.com/sqs/goreturns
-	export GOPATH=$(shell pwd)/dist/macos/workspace; GOOS=darwin GOARCH=amd64 go get -u golang.org/x/tools/cmd/gorename
-	export GOPATH=$(shell pwd)/dist/macos/workspace; GOOS=darwin GOARCH=amd64 go get -u github.com/tpng/gopkgs
-	export GOPATH=$(shell pwd)/dist/macos/workspace; GOOS=darwin GOARCH=amd64 go get -u github.com/newhook/go-symbols
-	export GOPATH=$(shell pwd)/dist/macos/workspace; GOOS=darwin GOARCH=amd64 go get -u golang.org/x/tools/cmd/guru
-	export GOPATH=$(shell pwd)/dist/linux/workspace; GOOS=darwin GOARCH=amd64 go get -u github.com/cweill/gotests/...
-	@[ -d dist/macos/workspace/bin/darwin_amd64 ] && mv dist/macos/workspace/bin/darwin_amd64/* dist/macos/workspace/bin/ || echo 'move os arch binaries'
-	@[ -d dist/macos/workspace/bin/darwin_amd64 ] && rm -rf dist/macos/workspace/bin/darwin_amd64 || echo 'clean os arch binaries folder'
-	@echo '************************************'
-	@echo MACOS: prepare archive
-	@echo '************************************'
-	cd dist/macos; zip -q -r ../handsongo-macos.zip *
-	@cd ../..
+OS_MACOS_DIST_NAME=macos
+OS_MACOS_NAME=darwin
+OS_LINUX_DIST_NAME=linux
+OS_LINUX_NAME=linux
+OS_ARCH=amd64
+GOLANG_VERSION=1.9.2
+GOLANG_DEP_VERSION=v0.3.2
+VSCODE_MACOS_VERSION=620882
+VSCODE_LINUX_VERSION=620884
+VSCODE_GOLANG_PLUGIN_VERSION=0.6.66
+JQ_VERSION=1.5
+JQ_MACOS_ARCH=osx-amd64
+JQ_LINUX_ARCH=linux64
+DOCKER_GOLANG_IMAGE_VERSION=1.9-alpine
+DOCKER_MONGO_IMAGE_VERSION=3.4
 
-linux:
-	@rm -rf dist/linux
-	@mkdir -p dist/linux/apps
-	@echo '************************************'
-	@echo LINUX: prepare vscode app
-	@echo '************************************'
-	wget -q --output-document=$(shell pwd)/dist/linux/apps/vscode.tar.gz https://go.microsoft.com/fwlink/?LinkID=620884
-	wget -q --output-document=$(shell pwd)/dist/linux/apps/go.vsix https://lukehoban.gallery.vsassets.io/_apis/public/gallery/publisher/lukehoban/extension/Go/0.6.57/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage
-	tar -C $(shell pwd)/dist/linux/apps/ -xzf $(shell pwd)/dist/linux/apps/vscode.tar.gz
-	@rm $(shell pwd)/dist/linux/apps/vscode.tar.gz
-	@echo '************************************'
-	@echo LINUX: prepare golang app
-	@echo '************************************'
-	wget -q --output-document=$(shell pwd)/dist/linux/apps/go.tar.gz https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz
-	tar -C $(shell pwd)/dist/linux/apps/ -xzf $(shell pwd)/dist/linux/apps/go.tar.gz
-	@rm $(shell pwd)/dist/linux/apps/go.tar.gz
-	@echo '************************************'
-	@echo LINUX: prepare jq
-	@echo '************************************'
-	@mkdir -p $(shell pwd)/dist/linux/apps/bin
-	wget -q --output-document=$(shell pwd)/dist/linux/apps/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-	chmod +x $(shell pwd)/dist/linux/apps/bin/jq
-	@echo '************************************'
-	@echo LINUX: prepare glide
-	@echo '************************************'
-	@mkdir -p $(shell pwd)/dist/linux/tmp_glide
-	wget -q --output-document=$(shell pwd)/dist/linux/tmp_glide/glide.zip https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.zip
-	unzip -q $(shell pwd)/dist/linux/tmp_glide/glide.zip -d $(shell pwd)/dist/linux/tmp_glide/
-	@mkdir -p $(shell pwd)/dist/linux/workspace/bin/
-	mv $(shell pwd)/dist/linux/tmp_glide/**/glide $(shell pwd)/dist/linux/workspace/bin/
-	@rm -rf $(shell pwd)/dist/linux/tmp_glide
-	@echo '************************************'
-	@echo LINUX: prepare tools
-	@echo '************************************'
-	cp linux/* dist/linux/
-	cp vscode_settings.json dist/linux/
-	@echo '************************************'
-	@echo LINUX: prepare workspace
-	@echo '************************************'
-	@mkdir -p dist/linux/workspace/src/github.com/Sfeir
-	@mkdir -p dist/linux/workspace/bin
-	@mkdir -p dist/linux/workspace/pkg
-	git clone -q -b start https://github.com/Sfeir/handsongo.git dist/linux/workspace/src/github.com/Sfeir/handsongo
-	export GOPATH=$(shell pwd)/dist/linux/workspace; GOOS=linux GOARCH=amd64 go get -u github.com/nsf/gocode
-	export GOPATH=$(shell pwd)/dist/linux/workspace; GOOS=linux GOARCH=amd64 go get -u github.com/rogpeppe/godef
-	export GOPATH=$(shell pwd)/dist/linux/workspace; GOOS=linux GOARCH=amd64 go get -u github.com/golang/lint/golint
-	export GOPATH=$(shell pwd)/dist/linux/workspace; GOOS=linux GOARCH=amd64 go get -u github.com/lukehoban/go-outline
-	export GOPATH=$(shell pwd)/dist/linux/workspace; GOOS=linux GOARCH=amd64 go get -u sourcegraph.com/sqs/goreturns
-	export GOPATH=$(shell pwd)/dist/linux/workspace; GOOS=linux GOARCH=amd64 go get -u golang.org/x/tools/cmd/gorename
-	export GOPATH=$(shell pwd)/dist/linux/workspace; GOOS=linux GOARCH=amd64 go get -u github.com/tpng/gopkgs
-	export GOPATH=$(shell pwd)/dist/linux/workspace; GOOS=linux GOARCH=amd64 go get -u github.com/newhook/go-symbols
-	export GOPATH=$(shell pwd)/dist/linux/workspace; GOOS=linux GOARCH=amd64 go get -u golang.org/x/tools/cmd/guru
-	export GOPATH=$(shell pwd)/dist/linux/workspace; GOOS=linux GOARCH=amd64 go get -u github.com/cweill/gotests/...
-	@[ -d dist/linux/workspace/bin/linux_amd64 ] && mv dist/linux/workspace/bin/linux_amd64/* dist/linux/workspace/bin/ || echo 'move os arch binaries'
-	@[ -d dist/linux/workspace/bin/linux_amd64 ] && rm -rf dist/linux/workspace/bin/linux_amd64 || echo 'clean os arch binaries folder'
-	@echo '************************************'
-	@echo LINUX: prepare archive
-	@echo '************************************'
-	cd dist/linux; zip -q -r ../handsongo-linux.zip *
-	@cd ../..
+dist: macos linux docker ## Build all distributions
+	@rm -rf dist/$(OS_MACOS_DIST_NAME) dist/$(OS_LINUX_DIST_NAME) dist/docker
+	@cp INSTALLATION.md dist/
 
-docker:
-	@mkdir -p dist/docker
-	@echo '************************************'
-	@echo DOCKER: get images
-	@echo '************************************'
-	docker pull golang:1.8-alpine
-	docker pull mongo:3.3
-	@echo '************************************'
-	@echo DOCKER: save images
-	@echo '************************************'
-	docker save --output dist/docker/image-golang.tar golang:1.8-alpine
-	docker save --output dist/docker/image-mongo.tar mongo:3.3
-	@echo '************************************'
-	@echo DOCKER: prepare documentation
-	@echo '************************************'
-	cp docker/* dist/docker/
-	@echo '************************************'
-	@echo DOCKER: prepare archive
-	@echo '************************************'
-	cd dist/docker; zip -q -r ../handsongo-docker.zip *
-	@cd ../..
+macos: ## Build macos distribution
+	@./distribution.sh $(OS_MACOS_DIST_NAME) $(OS_MACOS_NAME) $(OS_ARCH) $(GOLANG_VERSION) $(GOLANG_DEP_VERSION) $(VSCODE_MACOS_VERSION) $(VSCODE_GOLANG_PLUGIN_VERSION) $(JQ_VERSION) $(JQ_MACOS_ARCH)
 
-.PHONY: macos linux dist docker
+linux: ## Build linux distribution
+	@./distribution.sh $(OS_LINUX_DIST_NAME) $(OS_LINUX_NAME) $(OS_ARCH) $(GOLANG_VERSION) $(GOLANG_DEP_VERSION) $(VSCODE_LINUX_VERSION) $(VSCODE_GOLANG_PLUGIN_VERSION) $(JQ_VERSION) $(JQ_LINUX_ARCH)
+
+docker: ## Build docker distribution
+	@./docker.sh $(DOCKER_GOLANG_IMAGE_VERSION) $(DOCKER_MONGO_IMAGE_VERSION)
+
+help: ## Print this message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: macos linux dist docker help

--- a/distribution.sh
+++ b/distribution.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+OS_DIST_NAME=$1
+OS_NAME=$2
+OS_ARCH=$3
+GOLANG_VERSION=$4
+GOLANG_DEP_VERSION=$5
+VSCODE_OS_VERSION=$6
+VSCODE_GOLANG_PLUGIN_VERSION=$7
+JQ_VERSION=$8
+JQ_OS_ARCH=$9
+
+SCRIPT_SCOPE="${OS_DIST_NAME} distribution"
+
+printf "%-20s | %-40s" "$SCRIPT_SCOPE" "prepare for ${OS_NAME} ${OS_ARCH}"
+rm -rf "dist/${OS_DIST_NAME}"
+mkdir -p "dist/${OS_DIST_NAME}/apps"
+cp "${OS_DIST_NAME}/"* "dist/${OS_DIST_NAME}/"
+printf "\e[1;32m%s\e[0m\n" "DONE"
+
+
+
+printf "%-20s | %-40s" "$SCRIPT_SCOPE" "prepare workspace"
+mkdir -p "dist/${OS_DIST_NAME}/workspace/src/github.com/Sfeir"
+mkdir -p "dist/${OS_DIST_NAME}/workspace/bin"
+mkdir -p "dist/${OS_DIST_NAME}/workspace/pkg"
+git clone -q -b start https://github.com/Sfeir/handsongo.git "dist/${OS_DIST_NAME}/workspace/src/github.com/Sfeir/handsongo"
+printf "\e[1;32m%s\e[0m\n" "DONE"
+
+
+
+printf "%-20s | %-40s" "$SCRIPT_SCOPE" "prepare golang (${GOLANG_VERSION})"
+wget -q --output-document="$(pwd)/dist/${OS_DIST_NAME}/apps/go.tar.gz" "https://storage.googleapis.com/golang/go${GOLANG_VERSION}.${OS_NAME}-${OS_ARCH}.tar.gz"
+tar -C "$(pwd)/dist/${OS_DIST_NAME}/apps/" -xzf "$(pwd)/dist/${OS_DIST_NAME}/apps/go.tar.gz"
+rm "$(pwd)/dist/${OS_DIST_NAME}/apps/go.tar.gz"
+printf "\e[1;32m%s\e[0m\n" "DONE"
+
+
+
+printf "%-20s | %-40s" "$SCRIPT_SCOPE" "prepare dep (${GOLANG_DEP_VERSION})"
+mkdir -p "$(pwd)/dist/${OS_DIST_NAME}/tmp_dep"
+wget -q --output-document="$(pwd)/dist/${OS_DIST_NAME}/tmp_dep/dep" "https://github.com/golang/dep/releases/download/${GOLANG_DEP_VERSION}/dep-${OS_NAME}-${OS_ARCH}"
+mkdir -p "$(pwd)/dist/${OS_DIST_NAME}/workspace/bin/"
+mv "$(pwd)/dist/${OS_DIST_NAME}/tmp_dep/dep" "$(pwd)/dist/${OS_DIST_NAME}/workspace/bin/dep"
+rm -rf "$(pwd)/dist/${OS_DIST_NAME}/tmp_dep"
+printf "\e[1;32m%s\e[0m\n" "DONE"
+
+
+
+printf "%-20s | %-40s" "$SCRIPT_SCOPE" "prepare vscode (stable)"
+if [ "${OS_DIST_NAME}" == "macos" ]; then
+    wget -q --output-document="$(pwd)/dist/${OS_DIST_NAME}/apps/vscode.zip" "https://go.microsoft.com/fwlink/?LinkID=${VSCODE_OS_VERSION}"
+    unzip -q "$(pwd)/dist/${OS_DIST_NAME}/apps/vscode.zip" -d "$(pwd)/dist/${OS_DIST_NAME}/apps/"
+    rm "$(pwd)/dist/${OS_DIST_NAME}/apps/vscode.zip"
+fi
+
+if [ "${OS_DIST_NAME}" == "linux" ]; then
+    wget -q --output-document="$(pwd)/dist/${OS_DIST_NAME}/apps/vscode.tar.gz" "https://go.microsoft.com/fwlink/?LinkID=${VSCODE_OS_VERSION}"
+    tar -C "$(pwd)/dist/${OS_DIST_NAME}/apps/" -xzf "$(pwd)/dist/${OS_DIST_NAME}/apps/vscode.tar.gz"
+    rm "$(pwd)/dist/${OS_DIST_NAME}/apps/vscode.tar.gz"
+fi
+cp vscode_settings.json "dist/${OS_DIST_NAME}/"
+printf "\e[1;32m%s\e[0m\n" "DONE"
+
+
+
+printf "%-20s | %-40s" "$SCRIPT_SCOPE" "prepare vscode golang plugin (${VSCODE_GOLANG_PLUGIN_VERSION})"
+wget -q --output-document="$(pwd)/dist/${OS_DIST_NAME}/apps/go.vsix" "https://lukehoban.gallery.vsassets.io/_apis/public/gallery/publisher/lukehoban/extension/Go/${VSCODE_GOLANG_PLUGIN_VERSION}/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
+printf "\e[1;32m%s\e[0m\n" "DONE"
+
+
+
+printf "%-20s | %-40s" "$SCRIPT_SCOPE" "prepare vscode golang tools"
+GOPATH="$(pwd)/dist/${OS_DIST_NAME}/workspace"
+export GOPATH
+
+GOOS="${OS_NAME}" GOARCH="${OS_ARCH}" go get -u \
+    github.com/ramya-rao-a/go-outline \
+    github.com/acroca/go-symbols \
+    github.com/nsf/gocode \
+    github.com/rogpeppe/godef \
+    golang.org/x/tools/cmd/godoc \
+    github.com/zmb3/gogetdoc \
+    github.com/golang/lint/golint \
+    github.com/fatih/gomodifytags \
+    github.com/uudashr/gopkgs/cmd/gopkgs \
+    golang.org/x/tools/cmd/gorename \
+    sourcegraph.com/sqs/goreturns \
+    github.com/cweill/gotests/... \
+    golang.org/x/tools/cmd/guru \
+    github.com/josharian/impl
+
+if [ -d "dist/${OS_DIST_NAME}/workspace/bin/${OS_NAME}_${OS_ARCH}" ]; then
+    mv "dist/${OS_DIST_NAME}/workspace/bin/${OS_NAME}_${OS_ARCH}/"* "dist/${OS_DIST_NAME}/workspace/bin/"
+fi
+if [ -d "dist/${OS_DIST_NAME}/workspace/bin/${OS_NAME}_${OS_ARCH}" ]; then
+    rm -rf "dist/${OS_DIST_NAME}/workspace/bin/${OS_NAME}_${OS_ARCH}"
+fi
+printf "\e[1;32m%s\e[0m\n" "DONE"
+
+
+
+printf "%-20s | %-40s" "$SCRIPT_SCOPE" "prepare jq (${JQ_VERSION})"
+mkdir -p "$(pwd)/dist/${OS_DIST_NAME}/apps/bin"
+wget -q --output-document="$(pwd)/dist/${OS_DIST_NAME}/apps/bin/jq" "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-${JQ_OS_ARCH}"
+chmod +x "$(pwd)/dist/${OS_DIST_NAME}/apps/bin/jq"
+printf "\e[1;32m%s\e[0m\n" "DONE"
+
+
+
+printf "%-20s | %-40s" "$SCRIPT_SCOPE" "prepare archive"
+cd "dist/${OS_DIST_NAME}" || exit
+zip -q -r "../handsongo-${OS_DIST_NAME}.zip" ./*
+printf "\e[1;32m%s\e[0m\n" "DONE"

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+SCRIPT_SCOPE="docker distribution"
+
+DOCKER_GOLANG_IMAGE_VERSION=$1
+DOCKER_MONGO_IMAGE_VERSION=$2
+
+mkdir -p dist/docker
+
+printf "%-20s | %-40s" "$SCRIPT_SCOPE" "get golang image (${DOCKER_GOLANG_IMAGE_VERSION})"
+docker pull "golang:${DOCKER_GOLANG_IMAGE_VERSION}" > /dev/null
+printf "\e[1;32m%s\e[0m\n" "DONE"
+
+printf "%-20s | %-40s" "$SCRIPT_SCOPE" "get mongo image (${DOCKER_MONGO_IMAGE_VERSION})"
+docker pull "mongo:${DOCKER_MONGO_IMAGE_VERSION}" > /dev/null
+printf "\e[1;32m%s\e[0m\n" "DONE"
+
+printf "%-20s | %-40s" "$SCRIPT_SCOPE" "save images"
+docker save --output dist/docker/image-golang.tar "golang:${DOCKER_GOLANG_IMAGE_VERSION}"
+docker save --output dist/docker/image-mongo.tar "mongo:${DOCKER_MONGO_IMAGE_VERSION}"
+printf "\e[1;32m%s\e[0m\n" "DONE"
+
+printf "%-20s | %-40s" "$SCRIPT_SCOPE" "prepare documentation"
+cp docker/* dist/docker/
+printf "\e[1;32m%s\e[0m\n" "DONE"
+
+printf "%-20s | %-40s" "$SCRIPT_SCOPE" "prepare archive"
+cd dist/docker || exit
+zip -q -r ../handsongo-docker.zip ./*
+printf "\e[1;32m%s\e[0m\n" "DONE"


### PR DESCRIPTION
- create distribution script for macos and linux distributions
- create docker script for docker images distribution
- bump version for go 1.9.2, vscode go plugin 0.6.66, go tools
- bump version for docker golang 1.9-alpine and mongo 3.4
- replace glide by dep 0.3.2
- fix gotests imports for macos (import the linux one)